### PR TITLE
Initial se targets

### DIFF
--- a/targets/EU/SE.json
+++ b/targets/EU/SE.json
@@ -1,0 +1,66 @@
+[
+    {
+        "name": "SweHosting",
+        "asn": 208453,
+        "ipv4": "193.181.23.1",
+        "ipv6": "2a07:54c1:f000::1",
+        "location": "Stockholm",
+        "category": "content"
+    },
+    {
+        "name": "Telia Sweden",
+        "asn": 3301,
+        "ipv4": "81.227.169.1",
+        "ipv6": false,
+        "location": "Stockholm",
+        "category": "isp"
+    },
+    {
+        "name": "Bahnhof",
+        "asn": 8473,
+        "ipv4": "46.59.116.178",
+        "ipv6": false,
+        "location": "Stockholm",
+        "category": "isp"
+    },
+    {
+        "name": "Tele2 Sweden",
+        "asn": 1257,
+        "ipv4": "77.218.34.1",
+        "ipv6": false,
+        "location": "Stockholm",
+        "category": "isp"
+    },
+    {
+        "name": "Telenor",
+        "asn": 2119,
+        "ipv4": "62.119.218.158",
+        "ipv6": false,
+        "location": "Stockholm",
+        "category": "isp"
+    },
+    {
+        "name": "Hi3G / 3 Sverige",
+        "asn": 44034,
+        "ipv4": "95.209.201.24",
+        "ipv6": false,
+        "location": "Stockholm",
+        "category": "isp"
+    },
+    {
+        "name": "Bredband 2 Sweden",
+        "asn": 29518,
+        "ipv4": "193.183.175.14",
+        "ipv6": false,
+        "location": "Stockholm",
+        "category": "isp"
+    },
+    {
+        "name": "NORDUnet",
+        "asn": 2603,
+        "ipv4": "109.105.114.9",
+        "ipv6": "2001:948:0:f005::2",
+        "location": "Stockholm",
+        "category": "edu"
+    }
+]

--- a/targets/EU/SE.json
+++ b/targets/EU/SE.json
@@ -16,6 +16,14 @@
         "category": "isp"
     },
     {
+        "name": "Arelion (fka. Telia Carrier)",
+        "asn": 1299,
+        "ipv4": "62.115.123.166",
+        "ipv6": false,
+        "location": "Stockholm",
+        "category": "carrier"
+    },
+    {
         "name": "Bahnhof",
         "asn": 8473,
         "ipv4": "46.59.116.178",
@@ -62,5 +70,13 @@
         "ipv6": "2001:948:0:f005::2",
         "location": "Stockholm",
         "category": "edu"
+    },
+    {
+        "name": "31173 Services AB",
+        "asn": 39351,
+        "ipv4": "193.138.216.14",
+        "ipv6": "2a03:1b20:1:f101::14",
+        "location": "Malmo",
+        "category": "content"
     }
 ]


### PR DESCRIPTION
This pull request adds a new target list for Sweden in the `targets/EU/SE.json` file. Initially, Stockholm is being targeted.

New Sweden targets added:

* Added `SweHosting` (content provider), including ASN, IPv4, IPv6, and location details.
* Added major ISPs: `Telia Sweden`, `Bahnhof`, `Tele2 Sweden`, `Telenor`, `Hi3G / 3 Sverige`, and `Bredband 2 Sweden`, each with ASN, IPv4, location, and category information.
* Added `NORDUnet` (educational network), including ASN, IPv4, IPv6, and location details.