### PR TITLE
Added Canadian networks

### DIFF
--- a/config/Targets
+++ b/config/Targets
@@ -1,5 +1,5 @@
 # Eranium SmokePing Targets Project
-# Generated on 2025-12-09 12:56:14
+# Generated on 2025-12-23 18:44:03
 # https://github.com/eranium/smokeping-targets
 
 *** Targets ***
@@ -569,6 +569,43 @@ host = 2a03:1b20:1:f101::14
 + NA
 menu = NA - North America
 title = NA - North America
+
+++ CA
+menu = CA - Canada
+title = CA - Canada
+
++++ 1403
+menu = EBOX | AS1403
+title = EBOX | AS1403
+host = 96.127.255.94
+
++++ 1403-IPV6
+menu = EBOX | AS1403 IPv6
+title = EBOX | AS1403 IPv6
+probe = FPing6
+host = 2606:6d00:0:99::b1b9
+
++++ 835
+menu = GoCodeIT | AS835
+title = GoCodeIT | AS835
+host = 170.39.230.155
+
++++ 835-IPV6
+menu = GoCodeIT | AS835 IPv6
+title = GoCodeIT | AS835 IPv6
+probe = FPing6
+host = 2602:fd50:0:f::3
+
++++ 60900
+menu = Ssmidge Technologies | AS60900
+title = Ssmidge Technologies | AS60900
+host = 170.39.49.1
+
++++ 60900-IPV6
+menu = Ssmidge Technologies | AS60900 IPv6
+title = Ssmidge Technologies | AS60900 IPv6
+probe = FPing6
+host = 2602:f50c:210::1
 
 ++ US
 menu = US - United States

--- a/targets/NA/CA.json
+++ b/targets/NA/CA.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "EBOX",
+    "asn": 1403,
+    "ipv4": "96.127.255.94",
+    "ipv6": "2606:6d00:0:99::b1b9",
+    "location": "Montreal, QC, CA",
+    "category": "isp"
+  },
+  {
+    "name": "GoCodeIT",
+    "asn": 835,
+    "ipv4": "170.39.230.155",
+    "ipv6": "2602:fd50:0:f::3",
+    "location": "Toronto, ON, CA",
+    "category": "content"
+  },
+  {
+    "name": "Ssmidge Technologies",
+    "asn": 60900,
+    "ipv4": "170.39.49.1",
+    "ipv6": "2602:f50c:210::1",
+    "location": "Montreal, QC, CA",
+    "category": "isp"
+  }
+]


### PR DESCRIPTION
Added:
EBOX (Residential and Business ISP) - IPs are from their Looking Glass
GoCodeIT/Xenyth (Hosting provider) - IPs are from their public Linux mirror
Ssmidge Technologies - Router loopbacks in Montreal